### PR TITLE
New command 'next:ignore' to ignore next control message during testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ script:
 deploy:
   provider: releases
   api_key:
+    # create this key using "travis setup releases"
+    # deployment only is triggered when 
+    # (1) a release is tagged
+    # (2) it is built from the repo named under on.repp below
+    # Hence, it is safe to built this with Travis from a forked
+    # (private) repo as the release step is not triggered.
     secure: IVMfBoWnV8Ci+HvtOCJiHDMrZEJ4GMjgk9wiJ4i9kRNAizNw6DhEh3O82gZ6MwOVP3RBofDqOgLeZZ2Cfq79UtIzM9WVViPl/bhhiTSzMViTlSPtbCDwHHWV/m/G53Kr10cfQeeeEJSOo32qVJhGZz/DCSbdrulmZNPcp5tGo+IzGxnKj7AqlsMIbNL/T/NFAvuI1k09rIwvQCm9OnLlN23EO7MyXRWcmVGuTrXGqQJA6B/Prq7jUno6JPhNbREGW9HRGDAh4/1ac+VHx5k1XZsPUw5Ow9H6PFXSYQQGuONu+GwxVBMNp5DxiRXdCgo+ZkWKulQzYL8c8IgeCM6/xHvSdMP2R3ATEJDO+32QTcLR9P4Uvq+vunEKSCRoDamLHEz6Zex1D0OOThHlm+aY4Db4buXAC6gzT7v0b4hlmTXGJlbIZ/Ove2q8q2T2P/8tdMtyj5hJ/adrEscdMRNq3RrjMH7yf6tUKX7+Ma+LB4ULykiT7TaqWLBARHYaEYPVQwEDaTaAhWuGC27foGmUZ1c6gCYzTD5u9xGms7alo5AjCBpe5xEaPeyP7f5zXnpIVypePabThuTPAOKPh/ffWqOfc+Zh4xpGmmnLdUAPI6T0Wwrk5kqaUUl0V9d0ZV/LlmI2RhTp5opgBKqYJrVv6HNN8DZmmD/06os5aG2mzkk=
   file: src/test-vm.xen.gz
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ script:
 deploy:
   provider: releases
   api_key:
-    # create this key using "travis setup releases"
-    # deployment only is triggered when 
+    # Create this key using "travis setup releases" on the command line.
+    # Deployment on Travis is triggered when 
     # (1) a release is tagged
-    # (2) it is built from the repo named under on.repp below
+    # (2) it is built from the repo named under on.repo below
     # Hence, it is safe to built this with Travis from a forked
     # (private) repo as the release step is not triggered.
     secure: IVMfBoWnV8Ci+HvtOCJiHDMrZEJ4GMjgk9wiJ4i9kRNAizNw6DhEh3O82gZ6MwOVP3RBofDqOgLeZZ2Cfq79UtIzM9WVViPl/bhhiTSzMViTlSPtbCDwHHWV/m/G53Kr10cfQeeeEJSOo32qVJhGZz/DCSbdrulmZNPcp5tGo+IzGxnKj7AqlsMIbNL/T/NFAvuI1k09rIwvQCm9OnLlN23EO7MyXRWcmVGuTrXGqQJA6B/Prq7jUno6JPhNbREGW9HRGDAh4/1ac+VHx5k1XZsPUw5Ow9H6PFXSYQQGuONu+GwxVBMNp5DxiRXdCgo+ZkWKulQzYL8c8IgeCM6/xHvSdMP2R3ATEJDO+32QTcLR9P4Uvq+vunEKSCRoDamLHEz6Zex1D0OOThHlm+aY4Db4buXAC6gzT7v0b4hlmTXGJlbIZ/Ove2q8q2T2P/8tdMtyj5hJ/adrEscdMRNq3RrjMH7yf6tUKX7+Ma+LB4ULykiT7TaqWLBARHYaEYPVQwEDaTaAhWuGC27foGmUZ1c6gCYzTD5u9xGms7alo5AjCBpe5xEaPeyP7f5zXnpIVypePabThuTPAOKPh/ffWqOfc+Zh4xpGmmnLdUAPI6T0Wwrk5kqaUUl0V9d0ZV/LlmI2RhTp5opgBKqYJrVv6HNN8DZmmD/06os5aG2mzkk=

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ install: 	all
 		ssh $(HOST) "test -d /boot/guest || mkdir /boot/guest"
 		ssh $(HOST) "cd /boot/guest; rm -f test-vm.xen"
 		scp src/test-vm.xen.gz $(HOST):/boot/guest
-		ssh $(HOST) "cd /boot/guest; gunzip test-vm.xen.gz"
 
 remove: 	
 		true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ using the Mirage unikernel framework.
 Binary releases are hosted on 
 [GitHub](https://github.com/xapi-project/xen-test-vm/releases) as
 `xen-test.vm.gz`. The uncompressed file is the kernel that needs to be
-installed.
+installed. You could use the following code in a script:
+
+```sh
+VERSION="0.0.5"
+NAME="xen-test-vm-$VERSION"
+GH="https://github.com/xapi-project"
+VM="$GH/xen-test-vm/releases/download/$VERSION/test-vm.xen.gz"
+KERNEL="xen-test-vm-${VERSION//./-}.xen.gz"
+
+curl --fail -s -L "$VM" > "$KERNEL"
+```
 
 # Installing the VM
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ release. The file goes into `/boot/guest` on a host:
 
     HOST=host
     ssh root@$HOST "test -d /boot/guest || mkdir /boot/guest"
-    scp test-vm.xen root@$HOST:/boot/guest
+    scp test-vm.xen.gz root@$HOST:/boot/guest
 
 The kernel needs to be registered with Xen on the host.  As root on
 `$HOST`, do:
 
     xe vm-create name-label=minion
     # this echoes a UUID for the new VM named "minion"
-    xe vm-param-set PV-kernel=/boot/guest/test-vm.xen uuid=$UUID
+    xe vm-param-set PV-kernel=/boot/guest/test-vm.xen.gz uuid=$UUID
     
 Once installed, use the CLI on the host to operate the VM or use
 XenCenter.
@@ -78,6 +78,7 @@ the hypervisor only sends these.
     reboot   
     halt     
     crash    
+    ignore
 
 ## Testing Messages
 
@@ -88,6 +89,7 @@ The kernel reads messages in "control/testing". Legal messages are:
     now:reboot   
     now:halt     
     now:crash    
+    now:ignore
 
 Each makes the kernel respond to these immediately. In addition, these
 messages are legal:
@@ -97,6 +99,7 @@ messages are legal:
     next:reboot   
     next:halt     
     next:crash    
+    next:ignore
 
 The next time the kernel receives a shutdown message, it ignores the
 message it received and acts on the next:message instead. This permits

--- a/src/commands.mli
+++ b/src/commands.mli
@@ -7,6 +7,7 @@ type shutdown =
   | Reboot
   | Halt
   | Crash
+  | Ignore
 
 type testing =
   | Now   of shutdown

--- a/src/commands.mll
+++ b/src/commands.mll
@@ -12,6 +12,7 @@
     | Reboot
     | Halt
     | Crash
+    | Ignore
 
   type testing =
     | Now   of shutdown
@@ -24,6 +25,7 @@
     | "reboot"    { Reboot }
     | "halt"      { Halt }
     | "crash"     { Crash }
+    | "ignore"    { Ignore }
     | _           { raise (Error "unknown shutdown command") }
 
   and testing = parse
@@ -45,6 +47,7 @@
       | Reboot    -> "reboot"
       | Halt      -> "halt"
       | Crash     -> "crash"
+      | Ignore    -> "ignore"
 
     let testing = function
       | Now(msg)  -> Printf.sprintf "now:%s"  (shutdown msg)

--- a/src/mirage_vm.ml
+++ b/src/mirage_vm.ml
@@ -62,9 +62,10 @@ module Main (C: V1_LWT.CONSOLE) = struct
     | CMD.Reboot    -> reboot ()
     | CMD.Halt      -> halt ()
     | CMD.Crash     -> crash ()
+    | CMD.Ignore    -> return false
 
 
-   (* event loop *)  
+  (* event loop *)  
   let start c = 
     OS.Xs.make () >>= fun client -> 
     let rec loop tick override = 


### PR DESCRIPTION
This pull request contains:
- a new control message `ignore`. The main purpose is to use it as `next:ignore` to make the kernel ignore the next shutdown message from the hypervisor for testing purposes.
- updated documentation for `ignore` and some small corrections in the README.
