### PR TITLE
CP-17113 Pin cstruct package to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN opam pin add -n -y mirage-bootvar-xen \
     git://github.com/jonludlam/mirage-bootvar-xen#better-parser
 RUN opam pin add -n -y minios-xen \
     git://github.com/jonludlam/mini-os#suspend-resume3
+
+RUN opam pin add -n -y cstruct 1.9.0
 RUN opam install -q -y mirage-xen
 RUN opam install -q -y mirage-console
 RUN opam install -q -y mirage-bootvar-xen

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ opam pin add -n -y mirage-bootvar-xen git://github.com/jonludlam/mirage-bootvar-
 
 opam pin add -n -y minios-xen git://github.com/jonludlam/mini-os#suspend-resume3
 
+opam pin add -n -y cstruct 1.9.0
 
 opam install -q -y mirage-xen
 opam install -q -y mirage-console


### PR DESCRIPTION
The Travis build is currently failing because the cstruct package move on upstream. We need to pin it. In the medium term, I'd like to remove the dependency on pinned packages.

Signed-off-by: Christian Lindig christian.lindig@citrix.com
